### PR TITLE
Fix configuration in platformio.ini file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:TTGO T7]
+[env:TTGO_T7]
 platform = espressif32
 board = ttgo-t7-v14-mini32
 framework = arduino


### PR DESCRIPTION
Replace whitespaces with underscores to avoid PlatformIO error: "Invalid environment name 'TTGO T7'. The name can contain alphanumeric, underscore, and hyphen characters (a-z, 0-9, -, _)"